### PR TITLE
Align markup with provided styles as example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,14 @@ const MyCustomDialog = props => {
   const dialog = ReactDOM.createPortal(
     <div {...attr.container} className='dialog-container'>
       <div {...attr.overlay} className='dialog-overlay' />
-      <div {...attr.dialog} className='dialog-element'>
+
+      <div {...attr.dialog} className='dialog-content'>
         <p {...attr.title} className='dialog-title'>
           Your dialog title
         </p>
+
         <p>Your dialog content</p>
+
         <button {...attr.closeButton} className='dialog-close'>
           Close dialog
         </button>


### PR DESCRIPTION
## Why?

Since I caught on using your open source in a personal project, I decided to fix this to potentially avoid others to identify where the issue is to begin with.

## What?
In the provided examples from styling docs, `-content` is expected instead of `-element`.

See provided [styling docs](https://a11y-dialog.netlify.app/usage/styling/).