### PR TITLE
Remove function body in declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ interface A11yDialogConfig {
 
 export function useA11yDialog(
   props: A11yDialogProps
-): [A11yDialogInstance, A11yDialogConfig] {}
+): [A11yDialogInstance, A11yDialogConfig]
 
 export class A11yDialog extends React.Component<
   React.PropsWithChildren<A11yDialogProps>,


### PR DESCRIPTION
Resolves the following ts errors in index.s.ts:

![image](https://user-images.githubusercontent.com/37670348/160379034-035e005c-ffa6-41f4-bcf7-d11c6b92a4f4.png)

`node_modules/react-a11y-dialog/index.d.ts:52:4 - error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.`
`node_modules/react-a11y-dialog/index.d.ts:52:43 - error TS1183: An implementation cannot be declared in ambient contexts.`