### PR TITLE
Re-export A11yDialogLib type to simplify dialogRef typing for consumers.

### DIFF
--- a/src/react-a11y-dialog.tsx
+++ b/src/react-a11y-dialog.tsx
@@ -88,6 +88,9 @@ export const useA11yDialog = (props: ReactA11yDialogProps) => {
   ] as [A11yDialogLib | null, Attributes]
 }
 
+// Re-export the `a11y-dialog` instance type for convenient typing of useRef/dialogRef.
+export type A11yDialogInstance = A11yDialogLib
+
 export const A11yDialog: React.FC<
   React.PropsWithChildren<ReactA11yDialogProps>
 > = props => {

--- a/src/react-a11y-dialog.tsx
+++ b/src/react-a11y-dialog.tsx
@@ -88,8 +88,8 @@ export const useA11yDialog = (props: ReactA11yDialogProps) => {
   ] as [A11yDialogLib | null, Attributes]
 }
 
-// Re-export the `a11y-dialog` instance type for convenient typing of useRef/dialogRef.
-export type A11yDialogInstance = A11yDialogLib
+// Re-export the `a11y-dialog` type for convenient typing of useRef/dialogRef.
+export type A11yDialog = A11yDialogLib
 
 export const A11yDialog: React.FC<
   React.PropsWithChildren<ReactA11yDialogProps>


### PR DESCRIPTION
Based on this issue: https://github.com/KittyGiraudel/react-a11y-dialog/issues/275, I am adding a new types export for the convenience of consumers of the library.

The use case I have in mind is setting up a ref like so: `const dialogRef = useRef<A11yDialogInstance>();`, with the issue being that `A11yDialogInstance` is not easily available.

So far, that type has had to be deduced either by pulling it out of `a11y-dialog` itself (risking falling out of sync if versions mismatch for some reason), or by playing around with the existing types in creative ways.

By exposing the type directly, users don't need to do mental gymnastics, and also don't need to pull types out of the parent library.