### PR TITLE
mark all node_modules as external

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import typescript from '@rollup/plugin-typescript'
 const min = filename => filename.replace('.js', '.min.js')
 const require = createRequire(import.meta.url)
 const pkg = require('./package.json')
-const externals = [...Object.keys(pkg.peerDependencies)]
+const externals = [/node_modules/]
 
 const plugins = [
   nodeResolve(),


### PR DESCRIPTION
only marking peerDeps as external is not enough. for packages, everything should be external, because the user's bundler already knows how to install the correct dependencies specified in `package.json#dependencies`.

closes #284, see https://github.com/KittyGiraudel/react-a11y-dialog/issues/284#issuecomment-1694648829

other improvements that should probably also be made (in different PRs):
- add `exports` field to package.json
- remove UMD build
- remove prop-types