### PR TITLE
remove `prop-types` in favor of typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "7.1.3",
       "license": "MIT",
       "dependencies": {
-        "a11y-dialog": "^8.0.1",
-        "prop-types": "^15.8.1"
+        "a11y-dialog": "^8.0.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.20.2",
@@ -7149,6 +7148,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7363,14 +7363,6 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
       "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
       "dev": true
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",
@@ -7639,21 +7631,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "a11y-dialog": "^8.0.1",
-    "prop-types": "^15.8.1"
+    "a11y-dialog": "^8.0.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",


### PR DESCRIPTION
as discussed in #285.

all props documentation has been moved into jsdocs. all default values have been moved into props destructuring.

all tests pass \:)