### PR TITLE
add `type: module` and `exports` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,26 @@
 {
   "name": "react-a11y-dialog",
+  "type": "module",
   "version": "7.2.0",
   "description": "A React component wrapper and React hook around a11y-dialog.",
   "homepage": "https://github.com/KittyGiraudel/react-a11y-dialog",
   "license": "MIT",
-  "main": "dist/react-a11y-dialog.js",
-  "module": "dist/react-a11y-dialog.esm.js",
+  "main": "dist/react-a11y-dialog.cjs",
+  "module": "dist/react-a11y-dialog.js",
   "types": "dist/react-a11y-dialog.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/react-a11y-dialog.d.ts",
+      "require": {
+        "development": "./dist/react-a11y-dialog.cjs",
+        "default": "./dist/react-a11y-dialog.min.cjs"
+      },
+      "import": {
+        "development": "./dist/react-a11y-dialog.js",
+        "default": "./dist/react-a11y-dialog.min.js"
+      }
+    }
+  },
   "files": [
     "dist/*"
   ],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,7 +5,7 @@ import commonjs from '@rollup/plugin-commonjs'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
 
-const min = filename => filename.replace('.js', '.min.js')
+const min = filename => filename.replace(/.(c?js)/, '.min.$1')
 const require = createRequire(import.meta.url)
 const pkg = require('./package.json')
 


### PR DESCRIPTION
this fixes ESM support using a combination of:
- adding `"type": "module"` to package.json
- changing file extension of cjs output to `.cjs`
- adding [`"exports"`](https://nodejs.org/api/packages.html#package-entry-points) field to map out entrypoints (esm, cjs, min, dev)

**important**: didn't remove CJS because it would be a breaking change.

now the only thing remaining is to externalize all dependencies.